### PR TITLE
Set options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ config :airbrake,
   ignore: :all # to disable reporting
 ```
 
+## Shared options for reporting data to Airbrake
+
+To include with every report to Airbrake a set of optional data, include the `:options` key in the config. This can either
+be a keyword list of options or a function that returns a keyword list of options. Keyword list keys that can be used are
+`:context`, `:params`, `:session`, and `:env`.
+
+### Options function in config
+
+A function for creating options for reporting should be declared in the config as a tuple of 
+`{ModuleName, :function_name}`. This function should take as an argument a keyword list, possibly empty and should
+return a keyword list.
+
+```elixir
+config :airbrake,
+  options: {Web, :airbrake_options}
+```
+
+### Options keyword list in config
+
+When options are provided as a keyword list in the configuration and a specific call to `Airbrake.report/2` includes 
+options in its parameters, the options will be merged, with the parameters taking precedence.
+
+```elixir
+config :airbrake,
+  options: [env: %{"SOME_ENVIRONMENT_VARIABLE" => "environment variable"}]
+```
+
 
 ## Custom usage examples
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ be a keyword list of options or a function that returns a keyword list of option
 ### Options function in config
 
 A function for creating options for reporting should be declared in the config as a tuple of 
-`{ModuleName, :function_name}`. This function should take as an argument a keyword list, possibly empty and should
-return a keyword list.
+`{ModuleName, :function_name, 1}`. This function should take as an argument a keyword list, possibly empty and should
+return a keyword list. The function arity is always 1.
 
 ```elixir
 config :airbrake,
-  options: {Web, :airbrake_options}
+  options: {Web, :airbrake_options, 1}
 ```
 
 ### Options keyword list in config

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -93,8 +93,8 @@ defmodule Airbrake.Worker do
 
   defp build_options(current_options) do
     case get_env(:options) do
-      base_options when is_function(base_options, 1) ->
-        base_options.(current_options)
+      {mod, fun} ->
+        apply(mod, fun, [current_options])
       shared_options when is_list(shared_options) ->
         Keyword.merge(shared_options, current_options)
       _ ->

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -84,9 +84,21 @@ defmodule Airbrake.Worker do
 
   defp send_report(exception, stacktrace, options) do
     unless ignore?(exception) do
-      payload = Airbrake.Payload.new(exception, stacktrace, options)
+      enhanced_options = build_options(options)
+      payload = Airbrake.Payload.new(exception, stacktrace, enhanced_options)
       json_encoder = Application.get_env(:airbrake, :json_encoder, Poison)
       HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
+    end
+  end
+
+  defp build_options(current_options) do
+    case get_env(:options) do
+      base_options when is_function(base_options, 1) ->
+        base_options.(current_options)
+      shared_options when is_list(shared_options) ->
+        Keyword.merge(shared_options, current_options)
+      _ ->
+        current_options
     end
   end
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -93,7 +93,7 @@ defmodule Airbrake.Worker do
 
   defp build_options(current_options) do
     case get_env(:options) do
-      {mod, fun} ->
+      {mod, fun, 1} ->
         apply(mod, fun, [current_options])
       shared_options when is_list(shared_options) ->
         Keyword.merge(shared_options, current_options)


### PR DESCRIPTION
## Description
This PR adds the ability to set Airbrake reporting options in the configuration for a project that is using this library. This is good for three things:

1. Being able to have the same options sent every time that `Airbrake.report/2` is invoked without having to set them explicitly with every call.
2. Being able to have options available when the `Airbrake.Plug` sends a report to Airbrake. 
3. Being able to have options available when a general error is reported to Airbrake.


## PR for upstream project
If this PR is approved, a PR will be opened in the [upstream project](https://github.com/romul/airbrake-elixir). For the time being, it will **NOT** be merged into master of this fork of that project, with the hope that it will be merged upstream first.

## Release available
A release has been created: https://github.com/CityBaseInc/airbrake-elixir/releases/tag/0.7.0.rc-2. This allows for testing of this code in other projects.
 
## Changes
* [x] check for `:options` in Airbrake config
* [x] use config options when available
 
 
## Justification for no test coverage
There is currently no test coverage for the `Airbrake.Worker` module. Adding coverage for the module is beyond the scope of the work for the current ticket.

More importantly, we would like increase the chances that the maintainer of the [upstream project](https://github.com/romul/airbrake-elixir) will approve a pull request and merge into the original project. In order to test, we would likely need to add in dependencies like double-bypass so that the tests would not make HTTP calls to Airbrake. I believe adding in extra things would make it less likely that the maintainer can focus on the core of this change, namely, the ability to set options in the configuration.
 
## Screenshots and examples

### Report when using a function to set the options

Configuration snippet
```elixir
config :airbrake,
  ...
  options: &Web.Helper.airbrake_options/1,
...
  logger_level: :error
```

Function snippet
```elixir
defmodule Web.Helper do
  @moduledoc """
  Helper functions for Web.
  """
...
  @spec airbrake_options(Keyword.t()) :: Keyword.t()
  def airbrake_options(options) do
    shared = [
      env: %{
        "KUBERNETES_ENVIRONMENT" => System.get_env("KUBERNETES_ENVIRONMENT"),
        "KUBERNETES_NAMESPACE" => System.get_env("KUBERNETES_NAMESPACE")
      }
    ]

    Keyword.merge(shared, options)
  end
end
```
![Screen Shot 2019-09-05 at 10 00 14 AM](https://user-images.githubusercontent.com/15874832/64353851-07a05b00-cfc4-11e9-8fcb-4c59d57eb66c.png)


### Report when using a keyword list to set the options
Configuration snippet
```elixir
config :airbrake,
  ...
  options: [
    env: %{
      "KUBERNETES_ENVIRONMENT" => System.get_env("KUBERNETES_ENVIRONMENT"),
      "KUBERNETES_NAMESPACE" => System.get_env("KUBERNETES_NAMESPACE")
    }
  ],
...
  logger_level: :error
```
![Screen Shot 2019-09-05 at 10 00 01 AM](https://user-images.githubusercontent.com/15874832/64353862-0b33e200-cfc4-11e9-889a-f8eef6d0f7bb.png)


